### PR TITLE
Fixes strip_key and adds filters and proxy_mode

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ MethodLength:
   Max: 200
 
 LineLength:
-  Max: 250
+  Max: 200
 
 AbcSize:
   Max: 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-### [Unreleased]
-- Add proxy_mode
-- Add basic auth authentication option.
-- Add filters
-- Add measurement templating mechanism
+## [Unreleased]
+### Added
+- Proxy_mode
+- Basic auth authentication option.
+- Filters
+- Measurement templating mechanism
 
 ### Fixed
 - strip_key was not working

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- Add proxy_mode
+- Add basic auth authentication option.
+- Add filters
 - Add measurement templating mechanism
 
 ## 0.0.2 - 2017-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-## [Unreleased]
+### [Unreleased]
 - Add proxy_mode
 - Add basic auth authentication option.
 - Add filters
 - Add measurement templating mechanism
+
+### Fixed
+- strip_key was not working
 
 ## 0.0.2 - 2017-05-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Check definitions can now specify a Sensu check extension to run,
 
 * `host`, `port`, `username`, `password` and `database` are pretty straight forward. If `use_ssl` is set to true, the connection to the influxdb server will be made using https instead of http.
 
+* `use_basic_auth` if your InfluxDB is behind a proxy that requires authentication you can set this to `true`, in that case you also have to define `basic_user` and `basic_pass`.
+
+* `filters` allow's you to "find and replace" words/patterns in the key, it's a Hash where the key is a regex pattern and the value is a string that should replace it. (these are passed directly to the gsub method). Filters are applyed before any other transformations like templates.
+
 * `templates` like with the InfluxDB Graphite plugin, you can specify patterns and formats, if the metric name matches the pattern, the template will be applied. Templates can be defined per check, in the check configuration, or globaly in the handler's configuration. Parts of the metric name will be converted into tags, reducing the measurement name in InfluxDB whilst keeping all the information as tags or fields.
 You can specifty multiple templates, if your metric matches more than one the first one will be used.
 For example, if you have a metric named:
@@ -191,11 +195,13 @@ Note that :
 * `time_precision` : global checks time precision (default is `'s'`)
 * `buffer_max_size` : buffer size limit before flush - This is the amount of points in the InfluxDB batch - (default is `500`)
 * `buffer_max_age` : buffer maximum age - Flush will be forced after this amount of time - (default is `6` seconds)
+* `Proxy mode` : If the extension is configured to be in proxy mode, it will skip the transformation step and assume that the data is valid [line protocol](https://docs.influxdata.com/influxdb/latest/write_protocols/line_protocol_reference). It will not take into account any tags defined in the sensu-configuration.
 
 ## Check options
 
 In the check config, an optional `influxdb` section can be added, containing a `database` option and `tags`.
-As mentioned above you can also specify `strip_metric` and `templates` in the check configuration.
+You can also set `proxy_mode` in this section on the checks to override the default configuration set on the handler. This way checks that use the InfluxDB line protocol can coexsist with checks that use the Graphite format and use the same handler.
+As mentioned above you can also specify `strip_metric`, `templates` and `filters`,  in the check configuration.
 If specified, this overrides the default `database` and `strip_metric` options in the handler config and adds (or overrides) influxdb tags and templates.
 
 This allows events to be written to different influxdb databases and modify key indexes on a check-by-check basis.

--- a/lib/sensu/extensions/history.rb
+++ b/lib/sensu/extensions/history.rb
@@ -25,7 +25,7 @@ module Sensu
 
       def post_init
         @influx_conf = parse_settings
-        logger.info("InfluxDB history extension initialiazed using #{@influx_conf['protocol']}://#{@influx_conf['host']}:#{@influx_conf['port']} - Defaults : db=#{@influx_conf['database']} precision=#{@influx_conf['time_precision']}")
+        logger.info("InfluxDB history extension initialiazed using #{@influx_conf['base_url']} - Defaults : db=#{@influx_conf['database']} precision=#{@influx_conf['time_precision']}")
 
         @relay = InfluxRelay.new
         @relay.init(@influx_conf)
@@ -71,6 +71,7 @@ module Sensu
         settings['buffer_max_age'] ||= 6 # seconds
         settings['port'] ||= 8086
         settings['scheme'] ||= 'sensu'
+        settings['base_url'] = "#{settings['protocol']}://#{settings['host']}:#{settings['port']}"
         return settings
       rescue => e
         logger.error("Failed to parse History settings #{e}")

--- a/lib/sensu/extensions/influxdb.rb
+++ b/lib/sensu/extensions/influxdb.rb
@@ -36,7 +36,8 @@ module Sensu
       def run(event_data)
         event = parse_event(event_data)
         if event[:check][:status] != 0
-          yield '', 0
+          logger.error("Check status is not OK!")
+          yield 'error', event[:check][:status]
           return
         end
         data = {}
@@ -59,7 +60,7 @@ module Sensu
           end
           @relay.push(event[:check][:influxdb][:database], event[:check][:time_precision], line)
         end
-        yield('', 0)
+        yield 'ok', 0
       end
 
       def stop

--- a/lib/sensu/extensions/influxdb.rb
+++ b/lib/sensu/extensions/influxdb.rb
@@ -36,26 +36,26 @@ module Sensu
       def run(event_data)
         event = parse_event(event_data)
         if event[:check][:status] != 0
-          logger.error("Check status is not OK!")
+          logger.error('Check status is not OK!')
           yield 'error', event[:check][:status]
           return
         end
         data = {}
         # init event and check data
-        data['client'] = event[:client][:name]
+        data[:client] = event[:client][:name]
         # This will merge : default conf tags < check embedded tags < sensu client/host tag
-        data['tags'] = @influx_conf['tags'].merge(event[:check][:influxdb][:tags]).merge('host' => data['client'])
+        data[:tags] = @influx_conf['tags'].merge(event[:check][:influxdb][:tags]).merge('host' => data[:client])
         # This will merge : check embedded templaes < default conf templates (check embedded templates will take precedence)
-        data['templates'] = event[:check][:influxdb][:templates].merge(@influx_conf['templates'])
-        data['filters'] = event[:check][:influxdb][:filters].merge(@influx_conf['filters'])
+        data[:templates] = event[:check][:influxdb][:templates].merge(@influx_conf['templates'])
+        data[:filters] = event[:check][:influxdb][:filters].merge(@influx_conf['filters'])
         event[:check][:influxdb][:database] ||= @influx_conf['database']
         event[:check][:time_precision] ||= @influx_conf['time_precision']
         event[:check][:influxdb][:strip_metric] ||= @influx_conf['strip_metric']
-        data['strip_metric'] = event[:check][:influxdb][:strip_metric]
-        data['duration'] = event[:check][:duration]
+        data[:strip_metric] = event[:check][:influxdb][:strip_metric]
+        data[:duration] = event[:check][:duration]
         event[:check][:output].split(/\r\n|\n/).each do |line|
           unless @influx_conf['proxy_mode'] || event[:check][:influxdb][:proxy_mode]
-            data['line'] = line
+            data[:line] = line
             line = parse_line(data)
           end
           @relay.push(event[:check][:influxdb][:database], event[:check][:time_precision], line)

--- a/lib/sensu/extensions/influxdb.rb
+++ b/lib/sensu/extensions/influxdb.rb
@@ -25,7 +25,7 @@ module Sensu
 
       def post_init
         @influx_conf = parse_settings
-        logger.info("InfluxDB extension initialiazed using #{@influx_conf['protocol']}://#{@influx_conf['host']}:#{@influx_conf['port']} - Defaults : db=#{@influx_conf['database']} precision=#{@influx_conf['time_precision']}")
+        logger.info("InfluxDB extension initialiazed using #{@influx_conf['base_url']} - Defaults : db=#{@influx_conf['database']} precision=#{@influx_conf['time_precision']}")
 
         @relay = InfluxRelay.new
         @relay.init(@influx_conf)
@@ -103,6 +103,7 @@ module Sensu
         settings['buffer_max_size'] ||= 500
         settings['buffer_max_age'] ||= 6 # seconds
         settings['port'] ||= 8086
+        settings['base_url'] = "#{settings['protocol']}://#{settings['host']}:#{settings['port']}"
         return settings
       rescue => e
         logger.error("Failed to parse InfluxDB settings #{e}")

--- a/lib/sensu/extensions/influxdb.rb
+++ b/lib/sensu/extensions/influxdb.rb
@@ -149,7 +149,7 @@ module Sensu
         if strip_metric == 'host'
           slice_host(key, hostname)
         elsif strip_metric
-          gsub(/^.*#{strip_metric}\.(.*$)/, '\1')
+          key.gsub(/^.*#{strip_metric}\.(.*$)/, '\1')
         end
       end
 

--- a/lib/sensu/extensions/influxdb/influx_relay.rb
+++ b/lib/sensu/extensions/influxdb/influx_relay.rb
@@ -19,7 +19,14 @@ module Sensu
         logger.info('Flushing Buffer')
         @buffer.each do |db, tp|
           tp.each do |p, points|
-            EventMachine::HttpRequest.new("#{@influx_conf['protocol']}://#{@influx_conf['host']}:#{@influx_conf['port']}/write?db=#{db}&precision=#{p}&u=#{@influx_conf['username']}&p=#{@influx_conf['password']}").post body: points.join("\n")
+            if @influx_conf['use_basic_auth']
+              EventMachine::HttpRequest.new("#{@influx_conf['protocol']}://#{@influx_conf['host']}:#{@influx_conf['port']}/write?db=#{db}&precision=#{p}&u=#{@influx_conf['username']}&p=#{@influx_conf['password']}").post(
+                body: points.join("\n"),
+                head: { 'authorization' => [@influx_conf['basic_user'], @influx_conf['basic_pass']] }
+              )
+            else
+              EventMachine::HttpRequest.new("#{@influx_conf['protocol']}://#{@influx_conf['host']}:#{@influx_conf['port']}/write?db=#{db}&precision=#{p}&u=#{@influx_conf['username']}&p=#{@influx_conf['password']}").post body: points.join("\n")
+            end
           end
           @buffer[db] = {}
         end

--- a/lib/sensu/extensions/influxdb/influx_relay.rb
+++ b/lib/sensu/extensions/influxdb/influx_relay.rb
@@ -19,13 +19,37 @@ module Sensu
         logger.info('Flushing Buffer')
         @buffer.each do |db, tp|
           tp.each do |p, points|
+            influxdb = EventMachine::HttpRequest.new("#{@influx_conf['base_url']}/write")
+            post_data = {}
+            post_data[:query] = { 'db' => db, 'precision' => p, 'u' => @influx_conf['username'], 'p' => @influx_conf['password'] }
+            post_data[:body] = points.join("\n")
             if @influx_conf['use_basic_auth']
-              EventMachine::HttpRequest.new("#{@influx_conf['protocol']}://#{@influx_conf['host']}:#{@influx_conf['port']}/write?db=#{db}&precision=#{p}&u=#{@influx_conf['username']}&p=#{@influx_conf['password']}").post(
-                body: points.join("\n"),
-                head: { 'authorization' => [@influx_conf['basic_user'], @influx_conf['basic_pass']] }
-              )
-            else
-              EventMachine::HttpRequest.new("#{@influx_conf['protocol']}://#{@influx_conf['host']}:#{@influx_conf['port']}/write?db=#{db}&precision=#{p}&u=#{@influx_conf['username']}&p=#{@influx_conf['password']}").post body: points.join("\n")
+              post_data[:head] = { 'authorization' => [@influx_conf['basic_user'], @influx_conf['basic_pass']] }
+            end
+            result = influxdb.post(post_data)
+            next if @influx_conf.key?(db) # this is to avoid the performance impact of checking the response everytime
+            result.callback do
+              if result.response =~ /.*error.*/
+                logger.error(result.response)
+                if result.response =~ /.*database not found.*/
+                  post_data = {}
+                  post_data[:body] = ''
+                  post_data[:query] = {
+                    'db' => db, 'precision' => p,
+                    'u' => @influx_conf['username'],
+                    'p' => @influx_conf['password'],
+                    'q' => "create database #{db}"
+                  }
+                  if @influx_conf['use_basic_auth']
+                    post_data[:head] = { 'authorization' => [@influx_conf['basic_user'], @influx_conf['basic_pass']] }
+                  end
+                  EventMachine::HttpRequest.new("#{@influx_conf['base_url']}/query").post(post_data)
+                  @influx_conf[db] = true
+                end
+              else
+                logger.debug("Written: #{post_data[:body]}")
+                @influx_conf[db] = true
+              end
             end
           end
           @buffer[db] = {}

--- a/lib/sensu/extensions/influxdb/influx_relay.rb
+++ b/lib/sensu/extensions/influxdb/influx_relay.rb
@@ -35,7 +35,8 @@ module Sensu
                   post_data = {}
                   post_data[:body] = ''
                   post_data[:query] = {
-                    'db' => db, 'precision' => p,
+                    'db' => db,
+                    'precision' => p,
                     'u' => @influx_conf['username'],
                     'p' => @influx_conf['password'],
                     'q' => "create database #{db}"


### PR DESCRIPTION
These changes are to fix the `strip_key` function and to add a feature to rename metric names using `filters`.
This also implements a `proxy_mode`, inspired on the work by @terjesannum 