### PR TITLE
Guarantee template order

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ Check definitions can now specify a Sensu check extension to run,
       "region": "my-dc-01",
       "stage": "prod"
     },
-    "templates": {
-      "^sensu\\.checks\\..*":"source.measurement.field*",
-      ".*\\.cgroup\\..*": "host.path.component"
-    }
+    "templates": [
+      {"^sensu\\.checks\\..*":"source.measurement.field*"},
+      {".*\\.cgroup\\..*": "host.path.component"}
+    ]
   }
 }
 ```

--- a/lib/sensu/extensions/influxdb.rb
+++ b/lib/sensu/extensions/influxdb.rb
@@ -163,7 +163,15 @@ module Sensu
         key = sanitize(key)
 
         tags = {}.merge(event[:tags])
-        event[:templates].each do |pattern, template|
+        event[:templates].each do |k, v|
+          if k.is_a?(Hash) # Array of Hashes
+            k = k.to_a.flatten
+            pattern = k[0]
+            template = k[1]
+          else # Hash of Hashes
+            pattern = k
+            template = v
+          end
           next unless key =~ /#{pattern}/
           template = template.split('.')
           key = key.split('.')


### PR DESCRIPTION
This PR is to address #12 
This code change keeps backwards compatibility whilst also allowing templates to be defined in an Array of Hashes instead of a Hash of Hashes.